### PR TITLE
Additions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include it/thexivn/random_maps_together/templates/*.xml
+include it/thexivn/random_maps_together/templates/*.Script.Txt

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # RandomMapTogether
 Simple pyplanet application to add RMC mode online 
+
+## Installation
+### docker
+If u don't know how to set up a TM2020 server I advise to use the following
+docker compose [RMT-Docker-server](https://github.com/thexivn/RMT-Docker-server).
+### requirements
+- TM2020
+- pyplanet
+### RMT
+1. clone the following repository 
+```bash 
+git clone https://github.com/thexivn/RandomMapTogether 
+cd RandomMapTogether
+```
+2. activate the `pyenv` in which `pyplanet` was installed
+``` bash
+pyenv activate pyplanet
+```
+3. Install the package. Use one of this follownog commands
+```bash
+python3 setup.py install
+#or
+pip install -e .
+```
+4. Add the package `'it.thexivn.random_maps_together'` to `apps.py`
+inside the pyplanet settings folder
+
+## configurations
+| ***setting***  | ***values***         | ***description***                                                                                                      |
+|----------------|----------------------|------------------------------------------------------------------------------------------------------------------------|
+| game_time      | int                  | time in `seconds`. Default 1h (3600s)                                                                                  |
+| AT_time        | AT, GOLD, SILVER     | time to beat to advance to next map                                                                                    |
+| GOLD_time      | GOLD, SILVER, BRONZE | time to beat that allow you to `take GOLD` and skip to next map                                                        |
+| min_perm_start | 0,1,2,3              | level required to start the game <br/>LEVEL_PLAYER = 0<br/>LEVEL_OPERATOR = 1<br/>LEVEL_ADMIN = 2<br/>LEVEL_MASTER = 3 |
+
+Also set `S_ForceLapsNb` to `-1`, this will use the validation laps for those 
+maps that have multi-laps

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ pip install -e .
 inside the pyplanet settings folder
 
 ## configurations
-| ***setting***  | ***values***         | ***description***                                                                                                      |
-|----------------|----------------------|------------------------------------------------------------------------------------------------------------------------|
-| game_time      | int                  | time in `seconds`. Default 1h (3600s)                                                                                  |
-| AT_time        | AT, GOLD, SILVER     | time to beat to advance to next map                                                                                    |
-| GOLD_time      | GOLD, SILVER, BRONZE | time to beat that allow you to `take GOLD` and skip to next map                                                        |
-| min_perm_start | 0,1,2,3              | level required to start the game <br/>LEVEL_PLAYER = 0<br/>LEVEL_OPERATOR = 1<br/>LEVEL_ADMIN = 2<br/>LEVEL_MASTER = 3 |
+| ***setting***       | ***values***         | ***description***                                                                                                      |
+|---------------------|----------------------|------------------------------------------------------------------------------------------------------------------------|
+| game_time           | int                  | time in `seconds`. Default 1h (3600s)                                                                                  |
+| AT_time             | AT, GOLD, SILVER     | time to beat to advance to next map                                                                                    |
+| GOLD_time           | GOLD, SILVER, BRONZE | time to beat that allow you to `take GOLD` and skip to next map                                                        |
+| min_perm_start      | 0,1,2,3              | level required to start the game <br/>LEVEL_PLAYER = 0<br/>LEVEL_OPERATOR = 1<br/>LEVEL_ADMIN = 2<br/>LEVEL_MASTER = 3 |
+| infinite_free_skips | bool                 | if enabled allow to always skips                                                                                       |
 
-Also set `S_ForceLapsNb` to `-1`, this will use the validation laps for those 
-maps that have multi-laps
+~~Also set `S_ForceLapsNb` to `-1`, this will use the validation laps for those 
+maps that have multi-laps~~ When the RMT game start automatically set `S_ForceLapsNb` to `-1`

--- a/it/thexivn/random_maps_together/Data/APIMapInfo.py
+++ b/it/thexivn/random_maps_together/Data/APIMapInfo.py
@@ -1,8 +1,12 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import date
+from typing import List
 
 
 @dataclass
 class APIMapInfo:
     uuid: str
     author_time: int
+    last_update: date
     content: bytes
+    tags: List[int]

--- a/it/thexivn/random_maps_together/Data/Configurations.py
+++ b/it/thexivn/random_maps_together/Data/Configurations.py
@@ -9,6 +9,7 @@ class Configurations:
     AT_time = SILVER
     GOLD_time = BRONZE
     min_level_to_start = 1
+    infinite_free_skips = False
 
     def set_game_time(self, old_value: str, seconds: str):
         if int(seconds) < 300:
@@ -30,3 +31,6 @@ class Configurations:
             level = 3
 
         self.min_level_to_start = level
+
+    def set_infinite_free_skips(self, old_value: bool, value: bool):
+        self.infinite_free_skips = value

--- a/it/thexivn/random_maps_together/Data/Configurations.py
+++ b/it/thexivn/random_maps_together/Data/Configurations.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from it.thexivn.random_maps_together.Data.Constants import SILVER, BRONZE
+from apps.it.thexivn.random_maps_together.Data.Constants import SILVER, BRONZE
 
 
 @dataclass
@@ -10,8 +10,9 @@ class Configurations:
     GOLD_time = BRONZE
     min_level_to_start = 1
     infinite_free_skips = False
+    tags = ""
 
-    def set_game_time(self, old_value: str, seconds: str):
+    def set_game_time(self, old_value, seconds):
         if int(seconds) < 300:
             self.game_time_seconds = 300
         else:
@@ -23,7 +24,7 @@ class Configurations:
     def set_gold_time(self, old_value: str, value: str):
         self.GOLD_time = value
 
-    def set_min_level_to_start(self, old_value: str, value: str):
+    def set_min_level_to_start(self, old_value, value):
         level = int(value)
         if level < 0:
             level = 0
@@ -34,3 +35,6 @@ class Configurations:
 
     def set_infinite_free_skips(self, old_value: bool, value: bool):
         self.infinite_free_skips = value
+
+    def set_tags(self, old_value: str, value: str):
+        self.tags = value

--- a/it/thexivn/random_maps_together/Data/Constants.py
+++ b/it/thexivn/random_maps_together/Data/Constants.py
@@ -1,4 +1,9 @@
+import datetime
+
 AT = 'AT'
 GOLD = 'GOLD'
 SILVER = 'SILVER'
 BRONZE = 'BRONZE'
+TAG_BOBSLEIGH = 44
+TAG_ICE = 14
+ICE_CHANGE_DATE = datetime.date(2022, 10, 1)

--- a/it/thexivn/random_maps_together/Data/GameScore.py
+++ b/it/thexivn/random_maps_together/Data/GameScore.py
@@ -29,11 +29,11 @@ class GameScore:
     def inc_gold(self):
         self.total_gold += 1
 
-    def get_top_10(self) -> List[PlayerScoreInfo]:
+    def get_top(self, amount=10) -> List[PlayerScoreInfo]:
         if self.player_finishes and len(self.player_finishes) >= 1:
             finishes_scores = [key_val[1] for key_val in self.player_finishes.items()]
             finishes_scores.sort(key=lambda player_score: -player_score.player_AT)
-            return finishes_scores[:min(len(self.player_finishes), 10)]
+            return finishes_scores[:min(len(self.player_finishes), amount)]
 
         return []
 

--- a/it/thexivn/random_maps_together/MapHandler.py
+++ b/it/thexivn/random_maps_together/MapHandler.py
@@ -8,7 +8,7 @@ from pyplanet.contrib.map import MapManager
 from pyplanet.contrib.map.exceptions import MapNotFound
 from pyplanet.core.storage.storage import Storage
 
-from it.thexivn.random_maps_together import AT, GOLD, SILVER, BRONZE
+from it.thexivn.random_maps_together import AT, GOLD, SILVER, BRONZE, TAG_BOBSLEIGH, TAG_ICE, ICE_CHANGE_DATE
 from it.thexivn.random_maps_together.Data import Configurations
 from it.thexivn.random_maps_together.Data.APIMapInfo import APIMapInfo
 from it.thexivn.random_maps_together.RestClient.TMNXRestClient import TMNXRestClient
@@ -25,6 +25,7 @@ class MapHandler:
         self._storage = storage
         self._configs: Configurations = configs
         self.active_map: Map = None
+        self.current_map_is_skipable = False
         self._nex_map: Optional[APIMapInfo] = None
 
     async def load_next_map(self):
@@ -32,6 +33,8 @@ class MapHandler:
         random_map = self._nex_map if self._nex_map else self._tmnx_rest_client.get_random_map()
         self._nex_map = None
         map_to_remove = self._map_manager.current_map
+        self.current_map_is_skipable = (TAG_BOBSLEIGH in random_map.tags or TAG_ICE in random_map.tags) and random_map.last_update < ICE_CHANGE_DATE
+        logger.info(f'TAGS: {random_map.tags} UPDATE: {random_map.last_update}')
         logger.info(f'uploading {random_map.uuid}.Map.Gbx to the server...')
         await self._map_manager.upload_map(io.BytesIO(random_map.content),
                                            f'{random_map.uuid}.Map.Gbx', overwrite=True)

--- a/it/thexivn/random_maps_together/MapHandler.py
+++ b/it/thexivn/random_maps_together/MapHandler.py
@@ -8,13 +8,12 @@ from pyplanet.contrib.map import MapManager
 from pyplanet.contrib.map.exceptions import MapNotFound
 from pyplanet.core.storage.storage import Storage
 
-from it.thexivn.random_maps_together import AT, GOLD, SILVER, BRONZE, TAG_BOBSLEIGH, TAG_ICE, ICE_CHANGE_DATE
-from it.thexivn.random_maps_together.Data import Configurations
-from it.thexivn.random_maps_together.Data.APIMapInfo import APIMapInfo
-from it.thexivn.random_maps_together.RestClient.TMNXRestClient import TMNXRestClient
+from apps.it.thexivn.random_maps_together import AT, GOLD, SILVER, BRONZE, TAG_BOBSLEIGH, TAG_ICE, ICE_CHANGE_DATE
+from apps.it.thexivn.random_maps_together.Data import Configurations
+from apps.it.thexivn.random_maps_together.Data.APIMapInfo import APIMapInfo
+from apps.it.thexivn.random_maps_together.RestClient.TMNXRestClient import TMNXRestClient
 
 logger = logging.getLogger(__name__)
-
 
 class MapHandler:
     def __init__(self, map_manager: MapManager, storage: Storage, configs: Configurations):
@@ -25,28 +24,32 @@ class MapHandler:
         self._storage = storage
         self._configs: Configurations = configs
         self.active_map: Map = None
+        self.current_map: APIMapInfo = None
         self.current_map_is_skipable = False
         self._nex_map: Optional[APIMapInfo] = None
 
     async def load_next_map(self):
         logger.info('Trying to load next map ...')
-        random_map = self._nex_map if self._nex_map else self._tmnx_rest_client.get_random_map()
+        random_map = self._nex_map if self._nex_map else self._tmnx_rest_client.get_random_map(self._configs.tags)
         self._nex_map = None
         map_to_remove = self._map_manager.current_map
-        self.current_map_is_skipable = (TAG_BOBSLEIGH in random_map.tags or TAG_ICE in random_map.tags) and random_map.last_update < ICE_CHANGE_DATE
+        self.current_map_is_skipable = (
+                                           TAG_BOBSLEIGH in random_map.tags or TAG_ICE in random_map.tags) and random_map.last_update < ICE_CHANGE_DATE
+
         logger.info(f'TAGS: {random_map.tags} UPDATE: {random_map.last_update}')
         logger.info(f'uploading {random_map.uuid}.Map.Gbx to the server...')
         await self._map_manager.upload_map(io.BytesIO(random_map.content),
                                            f'{random_map.uuid}.Map.Gbx', overwrite=True)
         await self._map_manager.update_list(True, True)
         logger.info('UPLOAD COMPLETE')
+        self.current_map = random_map
         await self._map_manager.set_current_map(random_map.uuid)
         await self._map_manager.remove_map(map_to_remove, True)
         logger.info('map loaded')
 
     def pre_load_next_map(self):
         try:
-            self._nex_map = self._tmnx_rest_client.get_random_map()
+            self._nex_map = self._tmnx_rest_client.get_random_map(self._configs.tags)
         except:
             self._nex_map = None
             logger.warning('Preload failed')
@@ -55,7 +58,10 @@ class MapHandler:
         logger.info('loading HUB map ...')
         if await self._map_exists(self._hub_map):
             logger.info('HUB map was already loaded')
-            await self._map_manager.set_current_map(self._hub_map)
+            try:
+                await self._map_manager.set_current_map(self._hub_map)
+            except Exception as e:
+                logger.error('Exception while loading HUB map', exc_info=e)
             return
 
         content = self._tmnx_rest_client.map_map_content(self._hub_id)
@@ -109,7 +115,7 @@ class MapHandler:
     async def _map_exists(self, uuid: str) -> bool:
         try:
             db_map = await self._map_manager.get_map(uuid)
-            return await self._storage.driver.exists(db_map.file)
+            return await self._storage.driver.exists(self._storage.MAP_FOLDER + "/" + db_map.file)
         except MapNotFound as not_found:
             logger.exception('Failed to get MAP %s', uuid, exc_info=not_found)
             return False

--- a/it/thexivn/random_maps_together/RMTGame.py
+++ b/it/thexivn/random_maps_together/RMTGame.py
@@ -98,7 +98,7 @@ class RMTGame:
 
     async def command_stop_rmt(self, player: Player, *args, **kwargs):
         if self._game_state.is_game_stage():
-            if player == self._rmt_starter_player:
+            if self._is_player_allowed(player):
                 await self._chat(f'{player.nickname} stopped the current session')
                 await self.back_to_hub()
             else:
@@ -190,7 +190,7 @@ class RMTGame:
     async def command_skip_gold(self, player: Player, *args, **kwargs):
         if self._game_state.skip_command_allowed():
             if self._game_state.gold_skip_available:
-                if self._rmt_starter_player == player:
+                if self._is_player_allowed(player):
                     self._update_time_left()
                     self._game_state.set_map_completed_state()
                     await self._chat(f'{player.nickname} decided to GOLD skip')
@@ -208,7 +208,7 @@ class RMTGame:
     async def command_free_skip(self, player: Player, *args, **kwargs):
         if self._game_state.skip_command_allowed():
             if self._game_state.free_skip_available:
-                if self._rmt_starter_player == player:
+                if self._is_player_allowed(player):
                     self._update_time_left()
                     self._game_state.set_map_completed_state()
                     self._game_state.free_skip_available = False
@@ -228,6 +228,9 @@ class RMTGame:
 
     def _update_time_left(self):
         self._time_left -= int(py_time.time() - self._map_start_time)
+
+    def _is_player_allowed(self, player: Player) -> bool:
+        return player.level == Player.LEVEL_MASTER or player == self._rmt_starter_player
 
     async def hide_custom_scoreboard(self, count, time, *args, **kwargs):
         await self._scoreboard_ui.hide()

--- a/it/thexivn/random_maps_together/RMTGame.py
+++ b/it/thexivn/random_maps_together/RMTGame.py
@@ -9,12 +9,13 @@ from pyplanet.contrib.chat import ChatManager
 from pyplanet.contrib.mode import ModeManager
 from pyplanet.core.ui import GlobalUIManager
 
-from it.thexivn.random_maps_together import MapHandler
-from it.thexivn.random_maps_together.Data.Configurations import Configurations
-from it.thexivn.random_maps_together.Data.GameScore import GameScore
-from it.thexivn.random_maps_together.Data.GameState import GameState
-
-from it.thexivn.random_maps_together.views import RandomMapsTogetherView, RMTScoreBoard
+from apps.it.thexivn.random_maps_together import MapHandler
+from apps.it.thexivn.random_maps_together.Data.Configurations import Configurations
+from apps.it.thexivn.random_maps_together.Data.GameScore import GameScore
+from apps.it.thexivn.random_maps_together.Data.GameState import GameState
+from pyplanet.utils.times import format_time
+from apps.it.thexivn.random_maps_together.views import RandomMapsTogetherView, RMTScoreBoard, PollView, PollUpdaterView
+from pyplanet.views.generics import ask_confirmation
 
 BIG_MESSAGE = 'Race_BigMessage'
 
@@ -25,6 +26,42 @@ S_FORCE_LAPS_NB = 'S_ForceLapsNb'
 _lock = asyncio.Lock()
 
 logger = logging.getLogger(__name__)
+tmx_tags = [
+    {"ID": 0, "Name": "ALL RANDOM", "Color": ""},
+    {"ID": 1, "Name": "Race", "Color": ""}, {"ID": 2, "Name": "FullSpeed", "Color": ""},
+    {"ID": 3, "Name": "Tech", "Color": ""}, {"ID": 4, "Name": "RPG", "Color": ""},
+    {"ID": 5, "Name": "LOL", "Color": ""}, {"ID": 6, "Name": "Press Forward", "Color": ""},
+    {"ID": 7, "Name": "SpeedTech", "Color": ""}, {"ID": 8, "Name": "MultiLap", "Color": ""},
+    {"ID": 9, "Name": "Offroad", "Color": "705100"}, {"ID": 10, "Name": "Trial", "Color": ""},
+    {"ID": 11, "Name": "ZrT", "Color": "1a6300"}, {"ID": 12, "Name": "SpeedFun", "Color": ""},
+    {"ID": 13, "Name": "Competitive", "Color": ""}, {"ID": 14, "Name": "Ice", "Color": "05767d"},
+    {"ID": 15, "Name": "Dirt", "Color": "5e2d09"}, {"ID": 16, "Name": "Stunt", "Color": ""},
+    {"ID": 17, "Name": "Reactor", "Color": "d04500"}, {"ID": 18, "Name": "Platform", "Color": ""},
+    {"ID": 19, "Name": "Slow Motion", "Color": "004388"}, {"ID": 20, "Name": "Bumper", "Color": "aa0000"},
+    {"ID": 21, "Name": "Fragile", "Color": "993366"}, {"ID": 22, "Name": "Scenery", "Color": ""},
+    {"ID": 23, "Name": "Kacky", "Color": ""}, {"ID": 24, "Name": "Endurance", "Color": ""},
+    {"ID": 25, "Name": "Mini", "Color": ""}, {"ID": 26, "Name": "Remake", "Color": ""},
+    {"ID": 27, "Name": "Mixed", "Color": ""}, {"ID": 28, "Name": "Nascar", "Color": ""},
+    {"ID": 29, "Name": "SpeedDrift", "Color": ""}, {"ID": 30, "Name": "Minigame", "Color": "7e0e69"},
+    {"ID": 31, "Name": "Obstacle", "Color": ""}, {"ID": 32, "Name": "Transitional", "Color": ""},
+    {"ID": 33, "Name": "Grass", "Color": "06a805"}, {"ID": 34, "Name": "Backwards", "Color": "83aa00"},
+    {"ID": 35, "Name": "Freewheel", "Color": "f2384e"}, {"ID": 36, "Name": "Signature", "Color": "f1c438"},
+    {"ID": 37, "Name": "Royal", "Color": "ff0010"}, {"ID": 38, "Name": "Water", "Color": "69dbff"},
+    {"ID": 39, "Name": "Plastic", "Color": "fffc00"}, {"ID": 40, "Name": "Arena", "Color": ""},
+    {"ID": 41, "Name": "Freestyle", "Color": ""}, {"ID": 42, "Name": "Educational", "Color": ""},
+    {"ID": 43, "Name": "Sausage", "Color": ""}, {"ID": 44, "Name": "Bobsleigh", "Color": ""},
+    {"ID": 45, "Name": "Pathfinding", "Color": ""}, {"ID": 46, "Name": "FlagRush", "Color": "7a0000"},
+    {"ID": 47, "Name": "Puzzle", "Color": "459873"}, {"ID": 48, "Name": "Freeblocking", "Color": "ffffff"},
+    {"ID": 49, "Name": "Altered Nadeo", "Color": "3a3a3a"}, {"ID": 50, "Name": "SnowCar", "Color": "d3d3d3"},
+    {"ID": 51, "Name": "Wood", "Color": "814b00"}, {"ID": 52, "Name": "Underwater", "Color": "03afff"},
+    {"ID": 53, "Name": "Turtle", "Color": "6bb74e"},
+]
+
+def get_tag(id):
+    for tag in tmx_tags:
+        if tag['ID'] == id:
+            return tag['Name']
+    return ""
 
 
 def background_loading_map(map_handler: MapHandler):
@@ -35,7 +72,7 @@ def background_loading_map(map_handler: MapHandler):
 
 class RMTGame:
     def __init__(self, map_handler: MapHandler, chat: ChatManager, mode_manager: ModeManager,
-                 score_ui: RandomMapsTogetherView, config: Configurations, tm_ui_manager: GlobalUIManager):
+                 score_ui: RandomMapsTogetherView, config: Configurations, tm_ui_manager: GlobalUIManager, ui_manager):
         self._rmt_starter_player: Player = None
         self._score = GameScore()
         self._map_handler = map_handler
@@ -49,9 +86,12 @@ class RMTGame:
         self._game_state = GameState()
         self._score_ui.set_score(self._score)
         self._score_ui.set_game_state(self._game_state)
-        self._scoreboard_ui = RMTScoreBoard(self._score_ui.app, self._score)
+        self.scoreboard_ui = RMTScoreBoard(self._score_ui.app, self._score)
         self._tm_ui = tm_ui_manager
-
+        self.poll_votes = {}
+        self.poll_time = 0
+        self.poll_updater_widget = PollUpdaterView(self, ui_manager)
+        self.poll_widget = PollView(self, ui_manager)
         logger.info("RMT Game initialized")
 
     async def on_init(self):
@@ -60,7 +100,9 @@ class RMTGame:
         self._mode_settings = await self._mode_manager.get_settings()
         self._mode_settings[S_FORCE_LAPS_NB] = int(-1)
         await self.hide_timer()
+        await self.scoreboard_ui.display()
         await self._score_ui.display()
+        self.poll_widget.subscribe("vote", self.poll_do_vote)
         self._score_ui.subscribe("ui_gold_skips", self.command_skip_gold)
         self._score_ui.subscribe("ui_start_rmt", self.command_start_rmt)
         self._score_ui.subscribe("ui_stop_rmt", self.command_stop_rmt)
@@ -73,7 +115,7 @@ class RMTGame:
 
         if self._game_state.is_hub_stage():
             self._game_state.set_start_new_state()
-            await self._chat(f'{player.nickname} started new RMT, loading next map ...')
+            await self._chat(f'{player.nickname}$z$s started a new RMT, loading next map ...')
             self._rmt_starter_player = player
             self._time_left = self._config.game_time_seconds
             self._mode_settings[S_TIME_LIMIT] = self._time_left
@@ -107,12 +149,13 @@ class RMTGame:
         return retry < max_retry
 
     async def command_stop_rmt(self, player: Player, *args, **kwargs):
+
         if self._game_state.is_game_stage():
             if self._is_player_allowed(player):
-                await self._chat(f'{player.nickname} stopped the current session')
+                await self._chat(f'{player.nickname}$z$s stopped the RMT session!')
                 await self.back_to_hub()
             else:
-                await self._chat("you can't stop the RMT", player)
+                await self._chat("You can't stop the RMT", player)
         else:
             await self._chat("RMT is not started yet", player)
 
@@ -120,9 +163,9 @@ class RMTGame:
         if self._game_state.is_game_stage():
             logger.info("Back to HUB ...")
             await self.hide_timer()
-            self._scoreboard_ui.set_time_left(0)
+            self.scoreboard_ui.set_time_left(0)
             self._game_state.set_hub_state()
-            await self._scoreboard_ui.display()
+            # await self._scoreboard_ui.display()
             self._score.rest()
             await self._score_ui.hide()
             await self._map_handler.remove_loaded_map()
@@ -136,8 +179,8 @@ class RMTGame:
         self._score_ui.ui_controls_visible = True
         if self._game_state.is_game_stage():
             if self._map_handler.current_map_is_skipable:
-                await self._chat("$o$FB0 this track was created before the ICE physics change $z"
-                                 , self._rmt_starter_player)
+                await self._chat("$o$FB0 this track was created before the ICE physics change $z")
+
             self._game_state.set_new_map_in_game_state()
             Thread(target=background_loading_map, args=[self._map_handler]).start()
             self._score_ui.set_skippable_map(self._can_skip_map())
@@ -164,7 +207,6 @@ class RMTGame:
                 logger.info("Continue with %d time left", self._time_left)
                 await self._mode_manager.update_settings(self._mode_settings)
 
-
     async def on_map_finsh(self, player: Player, race_time: int, lap_time: int, cps, lap_cps, race_cps, flow,
                            is_end_race: bool, is_end_lap, raw, *args, **kwargs):
         logger.info(f'[on_map_finsh] {player.nickname} has finished the map with time: {race_time}ms')
@@ -183,10 +225,10 @@ class RMTGame:
                     self._game_state.set_map_completed_state()
                     await self.hide_timer()
                     _lock.release()  # with loading True don't need to lock
-                    await self._chat(f'AT TIME, congratulations to {player.nickname}')
+                    await self._chat(f'Author Time Reached! Congrats to {player.nickname}')
                     if await self.load_with_retry():
                         self._score.inc_at(player)
-                        await self._scoreboard_ui.display()
+                        await self.scoreboard_ui.display()
                         await self._score_ui.hide()
                     else:
                         await self.back_to_hub()
@@ -195,8 +237,8 @@ class RMTGame:
                     self._game_state.gold_skip_available = True
                     _lock.release()
                     await self._score_ui.display()
-                    await self._chat(f'first GOLD acquired, congrats to {player.nickname}')
-                    await self._chat('You are now allowed to Take the GOLD and skip the map', self._rmt_starter_player)
+                    await self._chat(f'Gold Time acquired! Congrats to {player.nickname}')
+                    await self._chat('You are allowed to Take the GOLD and skip the map. Use /gold_skip to start vote!')
                 else:
                     _lock.release()
             else:
@@ -208,11 +250,11 @@ class RMTGame:
                 if self._is_player_allowed(player):
                     self._update_time_left()
                     self._game_state.set_map_completed_state()
-                    await self._chat(f'{player.nickname} decided to GOLD skip')
+                    await self._chat(f'Admin decided to GOLD skip')
                     await self.hide_timer()
                     if await self.load_with_retry():
                         self._score.inc_gold()
-                        await self._scoreboard_ui.display()
+                        await self.scoreboard_ui.display()
                         await self._score_ui.hide()
                     else:
                         await self.back_to_hub()
@@ -221,24 +263,108 @@ class RMTGame:
         else:
             await self._chat("You are not allowed to skip", player)
 
-    async def command_free_skip(self, player: Player, *args, **kwargs):
-        if self._game_state.skip_command_allowed():
-            if self._can_skip_map():
-                if self._is_player_allowed(player):
-                    self._update_time_left()
-                    self._game_state.set_map_completed_state()
-                    if not self._map_handler.current_map_is_skipable:
-                        self._game_state.free_skip_available = False
-                    await self._chat(f'{player.nickname} decided to skip the map')
-                    await self.hide_timer()
-                    await self._scoreboard_ui.display()
-                    await self._score_ui.hide()
-                    if not await self.load_with_retry():
-                        await self.back_to_hub()
+    def get_gold_skip_allowed(self):
+        return self._game_state.skip_command_allowed() and self._game_state.gold_skip_available
+
+    def get_free_skip_allowed(self):
+        return self._game_state.skip_command_allowed() and self._can_skip_map()
+
+    async def command_vote_skip_gold(self, *args, **kwargs):
+        if self._game_state.gold_skip_available:
+            self._update_time_left()
+            self._game_state.set_map_completed_state()
+            await self._chat(f'Players decided to GOLD skip')
+            await self.hide_timer()
+            if await self.load_with_retry():
+                self._score.inc_gold()
+                await self.scoreboard_ui.display()
+                await self._score_ui.hide()
             else:
-                await self._chat("Free skip is not available", player)
+                await self.back_to_hub()
         else:
-            await self._chat("You are not allowed to skip", player)
+            await self._chat("Gold skip is not available")
+
+    async def command_free_skip(self, player: Player, *args, **kwargs):
+        cancel = bool(
+            await ask_confirmation(
+                player=player,
+                message=f'Force free skip? You sure?',
+                buttons=[{"name": "Yeah, do it!"}, {"name": "Nope"}],
+            )
+        )
+        if not cancel:
+            if self._game_state.skip_command_allowed():
+                if self._can_skip_map():
+                    if self._is_player_allowed(player):
+                        self._update_time_left()
+                        self._game_state.set_map_completed_state()
+                        if not self._map_handler.current_map_is_skipable:
+                            self._game_state.free_skip_available = False
+                        await self._chat(f'Admin decided to skip the map')
+                        await self.hide_timer()
+                        await self.scoreboard_ui.display()
+                        await self._score_ui.hide()
+                        if not await self.load_with_retry():
+                            await self.back_to_hub()
+                else:
+                    await self._chat("Free skip is not available", player)
+            else:
+                await self._chat("You are not allowed to skip", player)
+
+    async def command_vote_free_skip(self, *args, **kwargs):
+        if self._can_skip_map():
+            self._update_time_left()
+            self._game_state.set_map_completed_state()
+            if not self._map_handler.current_map_is_skipable:
+                self._game_state.free_skip_available = False
+            await self._chat(f'Players decided to skip the map')
+            await self.hide_timer()
+            await self.scoreboard_ui.display()
+            await self._score_ui.hide()
+            if not await self.load_with_retry():
+                await self.back_to_hub()
+        else:
+            await self._chat("Free skip is not available")
+
+    async def command_poll(self, player: Player, *args, **kwargs):
+        if player.level < 1:
+            await self._chat("Not allowed", player)
+            return
+        self.poll_votes = []
+        for tag in tmx_tags:
+            self.poll_votes.append({"ID": tag['ID'], "Name": tag['Name'], "Vote": 0 })
+
+        self.poll_time = int(py_time.time() + 60)
+        await self.poll_widget.display()
+        asyncio.ensure_future(self.poll_updater())
+
+    async def poll_result(self):
+        items = sorted(self.poll_votes, key=lambda x: x['Vote'], reverse=True)
+        i = 0
+        out = ""
+        for item in items:
+            if i >= 3:
+                break
+            if item['Vote'] > 0:
+                out += f"$fff$o{item['Vote']}$o  $0af{item['Name']}({item['ID']}),  "
+            i += 1
+        await self._chat("Top Votes: " + out)
+
+    async def poll_do_vote(self, player: Player, raw, entries, *args, **kwargs):
+        for item in self.poll_votes:
+            if item['ID'] == int(entries['tag']):
+                item['Vote'] += 1
+
+    async def poll_updater(self):
+        timeleft = int(self.poll_time - py_time.time())
+        if timeleft > 0:
+            await self.poll_updater_widget.display()
+            await asyncio.sleep(1)
+            asyncio.ensure_future(self.poll_updater())
+        else:
+            await self.poll_updater_widget.hide()
+            await self.poll_widget.hide()
+            await self.poll_result()
 
     async def hide_timer(self):
         self._mode_settings[S_TIME_LIMIT] = 0
@@ -246,24 +372,31 @@ class RMTGame:
 
     def _update_time_left(self):
         self._time_left -= int(py_time.time() - self._map_start_time)
-        self._scoreboard_ui.set_time_left(self._time_left)
+        self.scoreboard_ui.set_time_left(self._time_left)
 
     def _is_player_allowed(self, player: Player) -> bool:
-        return player.level == Player.LEVEL_MASTER or player == self._rmt_starter_player
+        return player.level == Player.LEVEL_OPERATOR or player == self._rmt_starter_player
 
     async def hide_custom_scoreboard(self, count, time, *args, **kwargs):
-        await self._scoreboard_ui.hide()
-        await self.set_original_scoreboard_visible(True)
+        pass
+        # await self._scoreboard_ui.hide()
+        # await self.set_original_scoreboard_visible(True)
 
     async def set_original_scoreboard_visible(self, visible: bool):
-        self._tm_ui.properties.set_visibility(RACE_SCORES_TABLE, visible)
-        self._tm_ui.properties.set_visibility(BIG_MESSAGE, visible)
-        await self._tm_ui.properties.send_properties()
+        pass
+        # self._tm_ui.properties.set_visibility(RACE_SCORES_TABLE, visible)
+        # self._tm_ui.properties.set_visibility(BIG_MESSAGE, visible)
+        # await self._tm_ui.properties.send_properties()
 
     async def set_time_left(self, count, time, *args, **kwargs):
         if self._game_state.is_game_stage():
             logger.info(f'ROUND_START {time} -- {count}')
             self._map_start_time = py_time.time()
+            tags = []
+            for tag in self._map_handler.current_map.tags:
+                tags.append(get_tag(tag) + f"({tag})")
+            await self._chat(f"Author Time: {format_time(self._map_handler.current_map.author_time)}")
+            await self._chat(f"Tags: {', '.join(tags)}")
 
     def _can_skip_map(self) -> bool:
         return self._game_state.free_skip_available or \

--- a/it/thexivn/random_maps_together/RMTGame.py
+++ b/it/thexivn/random_maps_together/RMTGame.py
@@ -57,7 +57,7 @@ class RMTGame:
         self._score_ui.subscribe("ui_free_skip", self.command_free_skip)
 
     async def command_start_rmt(self, player: Player, *args, **kwargs):
-        if player.level <= self._config.min_level_to_start:
+        if player.level < self._config.min_level_to_start:
             await self._chat("you are not allowed to start the game", player)
             return
 

--- a/it/thexivn/random_maps_together/RMTGame.py
+++ b/it/thexivn/random_maps_together/RMTGame.py
@@ -149,7 +149,6 @@ class RMTGame:
                 logger.info("Continue with %d time left", self._time_left)
                 await self._mode_manager.update_settings(self._mode_settings)
 
-        await self._score_ui.display()
 
     async def on_map_finsh(self, player: Player, race_time: int, lap_time: int, cps, lap_cps, race_cps, flow,
                            is_end_race: bool, is_end_lap, raw, *args, **kwargs):
@@ -240,3 +239,8 @@ class RMTGame:
         self._tm_ui.properties.set_visibility(RACE_SCORES_TABLE, visible)
         self._tm_ui.properties.set_visibility(BIG_MESSAGE, visible)
         await self._tm_ui.properties.send_properties()
+
+    async def set_time_left(self, count, time, *args, **kwargs):
+        if self._game_state.is_game_stage():
+            logger.info(f'ROUND_START {time} -- {count}')
+            self._map_start_time = py_time.time()

--- a/it/thexivn/random_maps_together/RestClient/TMNXRestClient.py
+++ b/it/thexivn/random_maps_together/RestClient/TMNXRestClient.py
@@ -5,17 +5,10 @@ from typing import List
 import requests
 from requests import Response
 
-from it.thexivn.random_maps_together.Data.APIMapInfo import APIMapInfo
+from apps.it.thexivn.random_maps_together.Data.APIMapInfo import APIMapInfo
 
 logger = logging.getLogger(__name__)
 
-SEARCH_PARAMS = {
-    'api': 'on',
-    'random': '1',
-    'lengthop': '1',
-    'length': '9',
-    'etags': '23,46,40,41,42,37'
-}
 
 
 def _get_tags(tags_str: str) -> List[int]:
@@ -33,23 +26,55 @@ def _fix_datetime(dtime: str) -> datetime:
 class TMNXRestClient:
     def __init__(self):
         self.base_url = "https://trackmania.exchange/mapsearch2/"
+        self.mirror_url = "https://map-monitor.xk.io/mapsearch2/"
         self.search_api = "search"
         self.download_url = "https://trackmania.exchange/maps/download/"
+        self.download_mirror = "https://map-monitor.xk.io/maps/download/"
+        self.headers = {'user-agent': 'pyplanet-rmt/1.0.0'}
+        self.tags = '5'
 
-    def get_random_map(self) -> APIMapInfo:
-        response: Response = requests.get(f'{self.base_url}{self.search_api}',
-                                          params=SEARCH_PARAMS)
 
-        first_map = response.json().get("results")[0]
-        return APIMapInfo(
-            first_map.get("TrackUID"),
-            int(first_map.get('AuthorTime')),
-            _fix_datetime(first_map.get("UpdatedAt")).date(),
-            self.map_map_content(first_map.get("TrackID")),
-            _get_tags(first_map.get("Tags")))
+    def get_random_map(self, tags=None) -> APIMapInfo:
+        params = {
+            'api': 'on',
+            'random': '1',
+            'lengthop': '3',    # 1
+            'length': '4',      # 9
+            'mtype': 'TM_Race',
+            'etags': '6,8,10,23,24,30,31,37,40,45,46,47'
+        }
+
+        if tags != " ":
+            params.update({"tags": tags})
+
+        response: Response = requests.get(f'{self.base_url}{self.search_api}', params=params)
+        if response.status_code == 200:
+            first_map = response.json().get("results")[0]
+            return APIMapInfo(
+                first_map.get("TrackUID"),
+                int(first_map.get('AuthorTime')),
+                _fix_datetime(first_map.get("UpdatedAt")).date(),
+                self.map_map_content(first_map.get("TrackID")),
+                _get_tags(first_map.get("Tags")))
+        else:
+            response: Response = requests.get(f'{self.mirror_url}{self.search_api}', params=params,
+                                              headers=self.headers)
+            first_map = response.json().get("results")[0]
+            return APIMapInfo(
+                first_map.get("TrackUID"),
+                int(first_map.get('AuthorTime')),
+                _fix_datetime(first_map.get("UpdatedAt")).date(),
+                self.map_mirror_content(first_map.get("TrackID")),
+                _get_tags(first_map.get("Tags")))
 
     def map_map_content(self, map_id) -> bytes:
         logger.info("downloading %s%s", self.download_url, map_id)
         content = requests.get(f'{self.download_url}{map_id}').content
+        logger.info("download completed for mapID %s", map_id)
+        return content
+
+    def map_mirror_content(self, map_id) -> bytes:
+        logger.info("downloading %s%s", self.download_mirror, map_id)
+        content = requests.get(f'{self.download_mirror}{map_id}').content
         logger.info("download completed for mapID %s", map_id)
         return content

--- a/it/thexivn/random_maps_together/__init__.py
+++ b/it/thexivn/random_maps_together/__init__.py
@@ -52,6 +52,9 @@ class RandomMapsTogetherApp(AppConfig):
         )
 
         await self.settings()
+        await self.instance.gbx.multicall(
+            self.instance.gbx.prepare('SetCallVoteRatios', [-1])
+        )
 
         mania_callback.player.player_connect.register(self.player_connect)
         logger.info("application initialized correctly")
@@ -73,16 +76,22 @@ class RandomMapsTogetherApp(AppConfig):
                                 'permission level to start the RMT', default=2,
                                 change_target=self.app_settings.set_min_level_to_start)
 
+        inf_skips: Setting = Setting('it.thexivn.RMT.infinite_free_skips', 'infinite_free_skips', Setting.CAT_BEHAVIOUR, bool,
+                                'if enabled allows to free skips always', default=False,
+                                change_target=self.app_settings.set_infinite_free_skips)
+
         await self.context.setting.register(
             game_time,
             at_time,
             gold_time,
-            perm
+            perm,
+            inf_skips
         )
         self.app_settings.set_game_time(3600, await game_time.get_value())
         self.app_settings.set_at_time(AT, await at_time.get_value())
         self.app_settings.set_gold_time(GOLD, await gold_time.get_value())
         self.app_settings.set_min_level_to_start(2, await perm.get_value())
+        self.app_settings.set_infinite_free_skips(False, await inf_skips.get_value())
 
     async def on_start(self):
         await super().on_start()

--- a/it/thexivn/random_maps_together/__init__.py
+++ b/it/thexivn/random_maps_together/__init__.py
@@ -40,6 +40,8 @@ class RandomMapsTogetherApp(AppConfig):
         mania_callback.map.map_begin.register(self.rmt_game.map_begin_event)
         mania_callback.flow.round_end.register(self.rmt_game.map_end_event)
         mania_callback.flow.match_end__end.register(self.rmt_game.hide_custom_scoreboard)
+        mania_callback.flow.round_start__end.register(self.rmt_game.set_time_left)
+
         await self.instance.command_manager.register(
             Command(command="start_rmt", target=self.rmt_game.command_start_rmt, description="load the game"),
             Command(command="stop_rmt", target=self.rmt_game.command_stop_rmt, description="return to lobby"),
@@ -91,6 +93,7 @@ class RandomMapsTogetherApp(AppConfig):
         mania_callback.map.map_begin.unregister(self.rmt_game.map_begin_event)
         mania_callback.flow.round_end.unregister(self.rmt_game.map_end_event)
         mania_callback.flow.match_end__end.unregister(self.rmt_game.hide_custom_scoreboard)
+        mania_callback.flow.round_start__end.unregister(self.rmt_game.set_time_left)
         await self.widget.destroy()
         self.instance.ui_manager.properties.set_visibility('Race_ScoresTable', True)
         self.instance.ui_manager.properties.set_visibility('Race_BigMessage', True)

--- a/it/thexivn/random_maps_together/_models/__init__.py
+++ b/it/thexivn/random_maps_together/_models/__init__.py
@@ -1,0 +1,5 @@
+from .rmtscores import RmtScores
+
+__all__ = [
+	'RmtScores',
+]

--- a/it/thexivn/random_maps_together/_models/rmtscores.py
+++ b/it/thexivn/random_maps_together/_models/rmtscores.py
@@ -1,0 +1,18 @@
+from peewee import *
+from pyplanet.core.db import TimedModel
+from pyplanet.apps.core.maniaplanet.models import Player
+
+
+class RmtScores(TimedModel):
+    score = IntegerField(default=0)
+
+    class Meta:
+        db_table = 'rmt_scores'
+
+
+class AtScores(TimedModel):
+    player = ForeignKeyField(Player, index=True)
+    at_score = IntegerField(default=0)
+
+    class Meta:
+        db_table = 'rmt_at_scores'

--- a/it/thexivn/random_maps_together/templates/mapinfo.Script.txt
+++ b/it/thexivn/random_maps_together/templates/mapinfo.Script.txt
@@ -1,0 +1,24 @@
+// #RequireContext CSmMlScriptIngame
+
+Void RenderMap() {
+    (Page.GetFirstChild("map_name") as CMlLabel).Value = Map.MapName;
+    (Page.GetFirstChild("map_author") as CMlLabel).Value = Map.AuthorNickName;
+    (Page.GetFirstChild("map_authortime") as CMlLabel).Value = TextLib::TimeToText(Map.MapInfo.TMObjective_AuthorTime, True, True);
+    (Page.GetFirstChild("map_goldtime") as CMlLabel).Value = TextLib::TimeToText(Map.MapInfo.TMObjective_GoldTime, True, True);
+}
+
+***OnInit***
+***
+    declare Text PrevDateText = "";
+    wait(Map != Null);
+    RenderMap();
+***
+
+***Loop***
+***
+    if (System.CurrentLocalDateText != PrevDateText) {
+        PrevDateText = System.CurrentLocalDateText;
+        RenderMap();
+    }
+***
+

--- a/it/thexivn/random_maps_together/templates/mapinfo.xml
+++ b/it/thexivn/random_maps_together/templates/mapinfo.xml
@@ -1,0 +1,13 @@
+{% extends 'core.views/uikit/v1/widget.xml' %}
+
+{% block content %}
+	<label id="map_name" pos="0 0" z-index="3" size="60 4" text="" valign="center2" textfont="GameFontExtraBold" textsize="1.5" halign="right" textemboss="1" />
+	<label id="map_author" pos="0 -3" z-index="3" size="60 4" text="" valign="center2" textfont="GameFontExtraBold" textsize="1" halign="right" textemboss="1"/>
+	<label id="map_authortime" pos="0 -6" z-index="3" size="60 4" textprefix="$fffAT: $2c0" text="" valign="center2" textfont="GameFontExtraBold" textsize="1" halign="right" textemboss="1"/>
+    <label id="map_goldtime" pos="0 -9" z-index="3" size="60 4" textprefix="$fffGOLD: $cb0" text=""  valign="center2" textfont="GameFontExtraBold" textsize="1" halign="right" textemboss="1"/>
+{% endblock %}
+
+{% block maniascript %}
+  <script><!--{% include 'core.views/uikit/v1/scripts/toggle_ui.Script.txt' %} --></script>
+  <script><!--{% include 'random_maps_together/mapinfo.Script.txt' %}--></script>
+{% endblock %}

--- a/it/thexivn/random_maps_together/templates/player_updater.xml
+++ b/it/thexivn/random_maps_together/templates/player_updater.xml
@@ -1,0 +1,10 @@
+<script><![CDATA[
+main() {
+  declare Text py_PlayerNames for This;
+  declare Integer py_ScoreUpdate for This;
+  declare Text[] py_PlayerAmounts for This;
+  py_ScoreUpdate = Now;
+  py_PlayerNames = """{{ playerjson|safe }}""";
+  py_PlayerAmounts = ["{{num_players}}", "{{max_players}}", "{{num_spectators}}", "{{max_spectators}}"];
+}
+]]></script>

--- a/it/thexivn/random_maps_together/templates/poll.Script.txt
+++ b/it/thexivn/random_maps_together/templates/poll.Script.txt
@@ -1,0 +1,156 @@
+#Include "MathLib" as ML
+#Include "TextLib" as TL
+#Include "TimeLib" as TiL
+#Struct Tag {
+	Integer ID;
+	Integer Vote;
+	Text Name;
+	Text Color;
+}
+
+#Struct K_Vote {
+	Integer Limit;
+	Tag[] Votes;
+}
+
+#Const Json """[
+    {"ID": 0, "Name": "ALL RANDOM", "Color": ""},
+    {"ID": 1, "Name": "Race", "Color": ""}, {"ID": 2, "Name": "FullSpeed", "Color": ""},
+    {"ID": 3, "Name": "Tech", "Color": ""}, {"ID": 4, "Name": "RPG", "Color": ""},
+    {"ID": 5, "Name": "LOL", "Color": ""}, {"ID": 6, "Name": "Press Forward", "Color": ""},
+    {"ID": 7, "Name": "SpeedTech", "Color": ""}, {"ID": 8, "Name": "MultiLap", "Color": ""},
+    {"ID": 9, "Name": "Offroad", "Color": "705100"}, {"ID": 10, "Name": "Trial", "Color": ""},
+    {"ID": 11, "Name": "ZrT", "Color": "1a6300"}, {"ID": 12, "Name": "SpeedFun", "Color": ""},
+    {"ID": 13, "Name": "Competitive", "Color": ""}, {"ID": 14, "Name": "Ice", "Color": "05767d"},
+    {"ID": 15, "Name": "Dirt", "Color": "5e2d09"}, {"ID": 16, "Name": "Stunt", "Color": ""},
+    {"ID": 17, "Name": "Reactor", "Color": "d04500"}, {"ID": 18, "Name": "Platform", "Color": ""},
+    {"ID": 19, "Name": "Slow Motion", "Color": "004388"}, {"ID": 20, "Name": "Bumper", "Color": "aa0000"},
+    {"ID": 21, "Name": "Fragile", "Color": "993366"}, {"ID": 22, "Name": "Scenery", "Color": ""},
+    {"ID": 23, "Name": "Kacky", "Color": ""}, {"ID": 24, "Name": "Endurance", "Color": ""},
+    {"ID": 25, "Name": "Mini", "Color": ""}, {"ID": 26, "Name": "Remake", "Color": ""},
+    {"ID": 27, "Name": "Mixed", "Color": ""}, {"ID": 28, "Name": "Nascar", "Color": ""},
+    {"ID": 29, "Name": "SpeedDrift", "Color": ""}, {"ID": 30, "Name": "Minigame", "Color": "7e0e69"},
+    {"ID": 31, "Name": "Obstacle", "Color": ""}, {"ID": 32, "Name": "Transitional", "Color": ""},
+    {"ID": 33, "Name": "Grass", "Color": "06a805"}, {"ID": 34, "Name": "Backwards", "Color": "83aa00"},
+    {"ID": 35, "Name": "Freewheel", "Color": "f2384e"}, {"ID": 36, "Name": "Signature", "Color": "f1c438"},
+    {"ID": 37, "Name": "Royal", "Color": "ff0010"}, {"ID": 38, "Name": "Water", "Color": "69dbff"},
+    {"ID": 39, "Name": "Plastic", "Color": "fffc00"}, {"ID": 40, "Name": "Arena", "Color": ""},
+    {"ID": 41, "Name": "Freestyle", "Color": ""}, {"ID": 42, "Name": "Educational", "Color": ""},
+    {"ID": 43, "Name": "Sausage", "Color": ""}, {"ID": 44, "Name": "Bobsleigh", "Color": ""},
+    {"ID": 45, "Name": "Pathfinding", "Color": ""}, {"ID": 46, "Name": "FlagRush", "Color": "7a0000"},
+    {"ID": 47, "Name": "Puzzle", "Color": "459873"}, {"ID": 48, "Name": "Freeblocking", "Color": "ffffff"},
+    {"ID": 49, "Name": "Altered Nadeo", "Color": "3a3a3a"}, {"ID": 50, "Name": "SnowCar", "Color": "d3d3d3"},
+    {"ID": 51, "Name": "Wood", "Color": "814b00"}, {"ID": 52, "Name": "Underwater", "Color": "03afff"},
+    {"ID": 53, "Name": "Turtle", "Color": "6bb74e"}
+]
+"""
+
+#Const TagsDisabled [6,8,10,23,24,30,31,37,40,45,46,47]
+declare Tag[] G_Tags;
+declare K_Vote G_Vote;
+
+Void SetSelected(Text tag) {
+	declare CMlFrame firstframe = Page.GetFirstChild("tags") as CMlFrame;
+	declare CMlEntry entry = Page.GetFirstChild("tag") as CMlEntry;
+	entry.Value = tag;
+	TriggerPageAction("rmt_poll__vote");
+
+	foreach (elem in firstframe.Controls) {
+			declare CMlFrame frame <=> elem as CMlFrame;
+			declare CMlLabel tick =	frame.GetFirstChild("tick") as CMlLabel;
+			tick.Opacity = 0.;
+			if (frame.DataAttributeGet("tag") == tag) {
+				tick.Opacity = 1.;
+				tick.RelativeScale = 1.5;
+				AnimMgr.Flush(tick);
+				AnimMgr.Add(tick, """<elem scale="1." />""", Now, 2000,  CAnimManager::EAnimManagerEasing::ElasticOut2);
+			}
+	}
+}
+
+Void renderTagList(Tag[] Tags) {
+	declare frame_tags = Page.GetFirstChild("tags") as CMlFrame;
+	declare row = -1;
+	declare col = 0;
+	declare idx = 0;
+	foreach(idd => elem in frame_tags.Controls) {
+		declare CMlFrame frame <=> elem as CMlFrame;
+			frame.Hide();
+			if (TagsDisabled.exists(idd)) continue;
+			if (!Tags.existskey(idd)) continue;
+			if (idx % 6 == 0) {
+				row +=1;
+				col = 0;
+			}
+			frame.DataAttributeSet("tag", ""^(idd));
+			frame.Show();
+			frame.RelativePosition_V3 = <35. * col, -row*8.>;
+			(frame.Controls[0] as CMlLabel).Value = Tags[idd].Name;
+			idx +=1;
+			col +=1;
+	}
+}
+
+Void updateVotes() {
+    declare frame_tags = Page.GetFirstChild("tags") as CMlFrame;
+    foreach(idd => elem in frame_tags.Controls) {
+        declare CMlFrame frame <=> elem as CMlFrame;
+        if (G_Vote.Votes.existskey(idd)) {
+           (frame.Controls[1] as CMlLabel).Value = ""^G_Vote.Votes[idd].Vote;
+        }
+    }
+}
+
+main() {
+	declare CMlQuad SelectedItem;
+	declare Text PreviousItem = "";
+	declare Integer PrevStamp = -1;
+    declare Integer poll_updater for This;
+    declare Text poll_data for This;
+
+	G_Tags.fromjson(Json);
+	renderTagList(G_Tags);
+
+	while(True) {
+		yield;
+        if (PrevStamp != poll_updater) {
+            PrevStamp = poll_updater;
+            G_Vote.fromjson(poll_data);
+            updateVotes();
+
+    	    declare CMlQuad quad = Page.GetFirstChild("timebar") as CMlQuad;
+		    declare CMlLabel info = Page.GetFirstChild("timeinfo") as CMlLabel;
+	  		declare Integer Limit = G_Vote.Limit;
+            declare Real size = 60 - (Limit/(60*1.)*60.);
+            size = ML::Clamp(size, 0., 60.);
+            quad.Size.X = size;
+            info.Value = TL::TimeToText(Limit*1000) ^"min";
+          }
+
+
+	foreach (Event in PendingEvents) {
+			if (Event.Type == CMlScriptEvent::Type::MouseOver) {
+
+				if (Event.Control.HasClass("select")) {
+							SelectedItem = (Event.Control as CMlQuad);
+							SelectedItem.Colorize = <0., 1., 0.>;
+				}
+			}
+			if (Event.Type == CMlScriptEvent::Type::MouseOut) {
+				if (Event.Control.HasClass("select")) {
+							SelectedItem = (Event.Control as CMlQuad);
+							SelectedItem.Colorize = <1. , 1., 1.>;
+					}
+			}
+			if (Event.Type == CMlScriptEvent::Type::MouseClick) {
+				if (Event.Control.HasClass("select") && SelectedItem != Null) {
+						declare Text out = SelectedItem.Parent.DataAttributeGet("tag");
+						if (PreviousItem == "") {
+							PreviousItem = out;
+							SetSelected(out);
+						}
+				}
+			}
+		}
+	}
+}

--- a/it/thexivn/random_maps_together/templates/poll.xml
+++ b/it/thexivn/random_maps_together/templates/poll.xml
@@ -1,0 +1,96 @@
+<framemodel id="tagitem">
+    <label pos="-11 4" z-index="5" size="25 4" text="Tagname" halign="left" valign="center" textsize="2"
+           textfont="GameFontSemiBold" textcolor="000"/>
+    <label pos="-14 3.5" z-index="6" size="4 4" text="0" halign="center" valign="center2" textsize="1" textcolor="fff"
+           textfont="GameFontExtraBold"/>
+    <quad class="select" pos="0 3.5" z-index="0" size="34 5" halign="center" style="UICommon64_1" substyle="BgFrame2"
+          colorize="fff" valign="center" scriptevents="1"/>
+    <label id="tick" opacity="0" pos="15 5" z-index="10" size="32 18" text="✔" halign="center" valign="center"
+           textfont="GameFontBlack" textcolor="20FF00FF" textsize="5" focusareacolor1="0000" focusareacolor2="0000"
+           textemboss="1"/>
+    <quad pos="-16 3.5" z-index="5" size="4 4" halign="left" style="UICommon64_1" substyle="BgFrame2" colorize="678"
+          valign="center"/>
+</framemodel>
+<frame>
+<quad id="bg" pos="0 70" z-index="-10" size="220 140" halign="center" style="UICommon64_1" substyle="BgFrame1"
+      colorize="456" scriptevents="1"/>
+<label pos="0 59" z-index="0" size="84 8" text="Vote For Tag" textfont="GameFontExtraBold" valign="center2"
+       halign="center" textsize="7"/>
+<label pos="0 52" z-index="0" size="200 8" text="You can't change vote once you have picked"
+       textfont="GameFontExtraBold" valign="center2" halign="center" textsize="3"/>
+
+<frame id="tags" pos="-90 30">
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+    <frameinstance modelid="tagitem"/>
+</frame>
+
+<frame pos="-20 47">
+    <label pos="-4 0" valign="center" halign="center" text="🕑" textsize="1" scale="1.6"/>
+    <label id="timeinfo" pos="40 0" valign="center" halign="left" text="1:20min" textsize="1" scale="1.2"/>
+    <frame pos="0 1" scale="0.6">
+        <frame pos="-5.75 0" size="70 5" z-index="4">
+            <quad id="timebar" pos="6.26 0.171" z-index="5" size="50 101" bgcolor="fff" opacity="1" rot="20"
+                  valign="center" halign="left"/>
+        </frame>
+        <frame pos="-5.75 0" size="70 5">
+            <quad pos="6.26 0.171" z-index="0" size="60 101" bgcolor="444" opacity="1" rot="20" valign="center"
+                  halign="left"/>
+        </frame>
+    </frame>
+</frame>
+</frame>
+<entry pos="900 900" id="tag" name="tag" default=""/>
+<script><!-- {% include 'random_maps_together/poll.Script.txt' %} --></script>

--- a/it/thexivn/random_maps_together/templates/score_board.xml
+++ b/it/thexivn/random_maps_together/templates/score_board.xml
@@ -1,6 +1,6 @@
-<frame pos="-80 80" size="160 160" z-idex="100">
+<frame pos="-80 80" size="160 160" z-idex="3">
     <quad pos="0 0" size="160 160"  bgcolor="101010EE"/>
-    <frame pos="20 -5" size="120 50" z-idex="101">
+    <frame pos="20 -5" size="120 50" z-idex="4">
         <label pos="60 -5" size="60 10" text="RMT SCORE" textsize="10"
                halign="center" valign="center" style="ManiaPlanetLogos" />
 
@@ -8,9 +8,12 @@
         <label pos="40 -25" size="30 20"  text="{{AT}}" textsize="8" textfont="RajdhaniMono" valign="center" halign="right" />
         <quad pos="70 -15"  size="20 20" image="https://i.imgur.com/0z7NmIr.png" autoscale="1" keepratio="Fit"/>
         <label pos="100 -25" size="30 20" text="{{GOLD}}" textsize="8" textfont="RajdhaniMono" valign="center" halign="right" />
+        {% if time_left %}
+            <label pos="5 -40" text="TIME LEFT: {{time_left}}" textsize="5" textfont="RajdhaniMono" />
+        {% endif %}
     </frame>
 
-    <frame pos="20 -50" size="120 100" z-idex="101">
+    <frame pos="20 -50" size="120 100" z-idex="4">
     {% for player_score in players %}
         <frame pos="0 {{ (-10 * loop.index0)}}" size="120 10">
             <quad pos="0 0" size="120 10" bgcolor="eeeeeeFF"/>

--- a/it/thexivn/random_maps_together/templates/score_board.xml
+++ b/it/thexivn/random_maps_together/templates/score_board.xml
@@ -1,29 +1,87 @@
-<frame pos="-80 80" size="160 160" z-idex="3">
-    <quad pos="0 0" size="160 160"  bgcolor="101010EE"/>
-    <frame pos="20 -5" size="120 50" z-idex="4">
-        <label pos="60 -5" size="60 10" text="RMT SCORE" textsize="10"
-               halign="center" valign="center" style="ManiaPlanetLogos" />
+<framemodel id="player">
+  <label id="rank" pos="2 2.5" z-index="1" size="10 5" text="1" textfont="GameFontSemiBold" halign="center"
+         valign="center2" textsize="2"/>
+  <quad id="flag" size="6 5" pos="12 2.6" z-index="1" valign="center" halign="center"
+        image="file://ZoneFlags/Path/World" keepratio="Fit"/>
+  <label id="nick" pos="18 2.5" z-index="1" size="65 5" textprefix="" text="" textfont="GameFontSemiBold"
+         halign="left" valign="center2" maxline="1" textsize="2.5"/>
+  <label id="score" pos="110 2.5" z-index="1" size="25 5" text="" halign="center" valign="center2"
+         textfont="GameFontSemiBold" textsize="2.5"/>
+  <quad id="bg" class="hover" z-index="0" pos="7.5 2.5" size="130 5"
+        image="file://Media/Painter/Stencils/15-Stripes/_Stripe0Grad/Brush.tga" modulatecolor="108AEE" halign="left"
+        valign="center" scriptevents="1"/>
+  <quad id="rankbg" size="10 5" pos="2 2.5" z-index="0" bgcolor="108AEE" valign="center" halign="center"/>
+</framemodel>
 
-        <quad pos="5 -15"   size="20 20" image="https://imgur.com/s9qP3Pr.png" autoscale="1" keepratio="Fit"/>
-        <label pos="40 -25" size="30 20"  text="{{AT}}" textsize="8" textfont="RajdhaniMono" valign="center" halign="right" />
-        <quad pos="70 -15"  size="20 20" image="https://i.imgur.com/0z7NmIr.png" autoscale="1" keepratio="Fit"/>
-        <label pos="100 -25" size="30 20" text="{{GOLD}}" textsize="8" textfont="RajdhaniMono" valign="center" halign="right" />
-        {% if time_left %}
-            <label pos="5 -38" text="TIME LEFT: {{time_left}}" textsize="5" textfont="RajdhaniMono" />
-        {% endif %}
-    </frame>
+<frame pos="0 60">
+	<frame pos="-73 6" z-index="2">
+		<label pos="0 1" z-index="4" size="67 9" text="RANDOM MAPS" textsize="5" textfont="GameFontSemiBold" halign="center" valign="top"/>
+		<label pos="0 -5" z-index="2" size="73 7" text="T O G E T H E R" textsize="5" textfont="GameFontBlack" halign="center" valign="top" textcolor="000"/>
+		<quad pos="0 -5" z-index="1" size="50 6.5" bgcolor="FFF" halign="center" valign="top"/>
+	</frame>
+<label hidden="1" pos="0 6" z-index="5" size="20 5" text="TIME LEFT" halign="center" valign="top"/>
+<label hidden="1" pos="1 2" z-index="5" text="{{time_left}}" textsize="5" textfont="GameFontExtraBold"  size="71.4 6.22" halign="center" valign="top"/>
 
-    <frame pos="20 -50" size="120 100" z-idex="4">
-    {% for player_score in players %}
-        <frame pos="0 {{ (-10 * loop.index0)}}" size="120 10">
-            <quad pos="0 0" size="120 10" bgcolor="eeeeeeFF"/>
-            <quad pos="1 -0.5" size="99 9" bgcolor="513877FF"/>
-            <quad pos="100 -0.5" size="19 9" bgcolor="333333FF"/>
-            <label pos="55 -4.5" size="55 9" text="{{player_score.player.nickname}}" textsize="3.5" textfont="RajdhaniMono"
-                               halign="center" valign="center" />
-            <label pos="110 -4.5" size="10 9" text="{{player_score.player_AT}}" textsize="3.5" textfont="RajdhaniMono"
-                               halign="left" valign="center" />
-        </frame>
-    {% endfor %}
-    </frame>
+<frame pos="30 8" z-index="5">
+	<quad pos="21 -3" z-index="1" size="10.4 25.8" style="UICommon64_1" substyle="BgFrame1" rot="90" modulatecolor="19C500FF" halign="left" valign="center"/>
+	<quad pos="0 0"  size="16 16" autoscale="1" keepratio="Fit" style="MedalsBig" substyle="MedalNadeoPerspective" z-index="3"/>
+	<label pos="23 -3.5" size="20 10"  text="{{AT}}" textsize="8" textfont="GameFontBlack"  halign="center" z-index="2"/>
 </frame>
+
+<frame pos="64 8" z-index="5">
+	<quad pos="21 -3" z-index="1" size="10.4 25.8" style="UICommon64_1" substyle="BgFrame1" rot="90" modulatecolor="C5B500FF" halign="left" valign="center"/>
+	<quad pos="0 0"  size="16 16" autoscale="1" keepratio="Fit" style="MedalsBig" substyle="MedalGoldPerspective" z-index="3"/>
+	<label pos="23 -3.5" size="20 10"  text="{{GOLD}}" textsize="8" textfont="GameFontBlack"  halign="center" z-index="2"/>
+</frame>
+
+	<quad pos="0 0" z-index="0" size="200 16" bgcolor="123" opacity="1" halign="center" valign="center"/>
+	<quad pos="-0 -6.82" z-index="-1" size="200 112" bgcolor="345" opacity="1" halign="center" valign="top"/>
+</frame>
+
+<frame pos="40 25" z-index="4">
+       {% for player_score in players %}
+	<frame pos="0 -{{ 6 * loop.index0 }}">
+		<quad pos="0 0" z-index="0" size="48 5" bgcolor="123" halign="left" valign="center"/>
+		<label pos="0 0" z-index="1" size="48 5" text="{{player_score.player.nickname}}" textsize="2.5" textfont="GameFontSemiBold"
+                               halign="left" valign="center2" />
+		<quad pos="50 0" z-index="0" size="12 5" bgcolor="FFF" halign="center" valign="center"/>
+		<label pos="50 0" z-index="1" size="12 5" text="{{player_score.player_AT}}" textsize="2.5" textfont="GameFontExtraBold"
+                               halign="center" valign="center2"  textcolor="000"/>
+	</frame>
+        {% endfor %}
+</frame>
+
+<frame id="scroll" z-index="6" pos="-98 50" valign="top" halign="left" size="135 110" scroll="1" scrollmax="0 600">
+	  <frame id="playercards" z-index="6">
+	    {% for i in range(0,150) %}
+	    <frameinstance id="player_{{i}}" data-index="{{i}}" modelid="player" pos="4 -{{ loop.index * 5.5}} }}"/>
+	    {% endfor %}
+	  </frame>
+    <quad z-index="-2" bgcolor="0000" size="135 2100" scriptevents="1" pos="0 0"/>
+</frame>
+
+
+<frame pos="50 45" id="details" z-index="10">
+  <quad id="flag" pos="0 0" z-index="1" size="15 15" keepratio="Fit" valign="center" halign="center" image="file://Media/Flags/FIN.dds"/>
+  <label id="path" pos="9 3" z-index="1" size="39.5 8" text="" textfont="GameFontRegular" halign="left"
+         valign="center2" maxline="1" textsize="3"/>
+  <label id="name" pos="9 -2" z-index="1" size="39.2 8" text="" textfont="GameFontBlack" halign="left"
+         valign="center2"
+         maxline="1" textsize="3"/>
+  <entry id="login" name="login" pos="900 -28" z-index="0" size="50 5" default="" halign="center" valign="center2"
+         textsize="1.75"/>
+  <entry id="userid" name="userid" pos="900 -32" z-index="0" size="50 5" default="" halign="center" valign="center2"
+         textsize="1.75"/>
+  <frame id="actions" pos="0 -11">
+    <label pos="32.8 0" size="22 6" text="🔎 Spectate" halign="center" valign="center2" textfont="GameFontRegular"
+           scriptevents="1" focusareacolor1="108AEE" focusareacolor2="0059A2" textsize="1.75" z-index="2"
+           id="p_spectate"/>
+    <label pos="8 0" size="22 6" text=" Profile" halign="center" valign="center2" textfont="GameFontRegular"
+           scriptevents="1" focusareacolor1="108AEE" focusareacolor2="0059A2" textsize="1.75" z-index="2"
+           id="p_profile"/>
+  </frame>
+</frame>
+
+<script>
+<!-- {% include "random_maps_together/scoretable.Script.txt" %} -->
+</script>

--- a/it/thexivn/random_maps_together/templates/score_board.xml
+++ b/it/thexivn/random_maps_together/templates/score_board.xml
@@ -9,7 +9,7 @@
         <quad pos="70 -15"  size="20 20" image="https://i.imgur.com/0z7NmIr.png" autoscale="1" keepratio="Fit"/>
         <label pos="100 -25" size="30 20" text="{{GOLD}}" textsize="8" textfont="RajdhaniMono" valign="center" halign="right" />
         {% if time_left %}
-            <label pos="5 -40" text="TIME LEFT: {{time_left}}" textsize="5" textfont="RajdhaniMono" />
+            <label pos="5 -38" text="TIME LEFT: {{time_left}}" textsize="5" textfont="RajdhaniMono" />
         {% endif %}
     </frame>
 

--- a/it/thexivn/random_maps_together/templates/scoretable.Script.txt
+++ b/it/thexivn/random_maps_together/templates/scoretable.Script.txt
@@ -1,0 +1,296 @@
+// #RequireContext CSmMlScriptIngame
+#Include "TextLib" as TL
+#Include "MathLib" as ML
+
+#Struct K_Details {
+    CMlQuad Flag;
+    CMlLabel Path;
+    CMlLabel Name;
+    CMlEntry UserId;
+    CMlEntry Login;
+}
+
+#Struct K_Player {
+    Text Login;
+    Text Nick;
+}
+
+
+declare Integer G_LastStamp;
+declare K_Details G_Details;
+declare Integer G_DetailsIndex;
+declare K_Player[] G_PlayerNames;
+declare Boolean G_OldPageStatus;
+declare Integer G_LastUpdate;
+
+Void RenderDetails() {
+    if (G_DetailsIndex > Scores.count) {
+        G_DetailsIndex = 0;
+    }
+    if (G_DetailsIndex < 0) {
+        G_DetailsIndex = 0;
+    }
+    declare CMlFrame frame <=> (Page.GetFirstChild("actions") as CMlFrame);
+    frame.Hide();
+    if (!Scores.existskey(G_DetailsIndex)) {
+        return;
+    }
+    frame.Show();
+
+    declare CSmScore Score <=> Scores[G_DetailsIndex];
+    declare CUser User <=> Score.User;
+    G_Details.Flag.ImageUrl = User.CountryFlagUrl;
+    G_Details.UserId.Value =  User.WebServicesUserId;
+    G_Details.Login.Value =  User.Login;
+    G_Details.Name.Value = "$fff" ^  User.ClubTag ^" $z$fff" ^ User.Name;
+    declare Text[] path = TL::Split("|", User.ZonePath);
+    if (path.count >= 2) {
+        G_Details.Path.Value = path[1] ^ "|" ^ path[2];
+    } else {
+        G_Details.Path.Value = "";
+    }
+}
+
+CSmPlayer GetPlayer(CUser User) {
+    foreach (Player in Players) {
+        if (Player.User == User) return Player;
+    }
+    return Null;
+}
+
+Text GetPlayerNick(CUser User) {
+    foreach(Player in G_PlayerNames) {
+        if (User.Login == Player.Login) {
+            return Player.Nick;
+        }
+    }
+    return User.Name;
+}
+
+Vec3 GetRankColor(Integer Rank) {
+  switch(Rank) {
+    case 1: return TL::ToColor("db0");
+    case 2: return TL::ToColor("aab");
+    case 3: return TL::ToColor("963");
+  }
+  return TL::ToColor("003");
+}
+
+Text GetServerInfo() {
+    declare Text Out = "";
+    declare Text[] py_PlayerAmounts for This = [];
+    if (py_PlayerAmounts.count == 4) {
+      Out ^=" " ^ py_PlayerAmounts[0] ^ "/" ^ py_PlayerAmounts[1];
+      Out ^="    " ^ py_PlayerAmounts[2] ^ "/" ^ py_PlayerAmounts[3];
+    }
+    return Out;
+}
+
+Void Render() {
+    declare CMlFrame PlayerCards = (Page.GetFirstChild("playercards") as CMlFrame);
+
+    declare Real max = 5.5 * (Scores.count-20);
+    if (max < 0) max = 0.;
+    PlayerCards.ScrollMax = <0., max>;
+
+    foreach(i => Elem in PlayerCards.Controls) {
+        declare CMlFrame frame <=> (Elem as CMlFrame);
+        if (frame == Null) continue;
+        frame.Hide();
+        if (Scores.existskey(i)) {
+            frame.Show();
+            declare CSmScore Score <=> Scores[i];
+            declare CMlLabel Rank = frame.GetFirstChild("rank") as CMlLabel;
+            declare CMlLabel Nick = frame.GetFirstChild("nick") as CMlLabel;
+            declare CMlLabel Time = frame.GetFirstChild("score") as CMlLabel;
+            declare CMlQuad Flag = frame.GetFirstChild("flag") as CMlQuad;
+            (frame.GetFirstChild("bg") as CMlQuad).ModulateColor = TL::ToColor("003"); //GetRankColor(i+1);
+            (frame.GetFirstChild("rankbg") as CMlQuad).BgColor = TL::ToColor("003"); //GetRankColor(i+1);
+
+            declare Text icon = "";
+            declare CSmPlayer player <=> GetPlayer(Score.User);
+            declare Text color = "$fff";
+            declare Text nick = GetPlayerNick(Score.User);
+            if (player != Null) {
+                if (player.RequestsSpectate) icon = "";
+            } else {
+                color = "$777";
+                nick = Score.User.Name;
+            }
+            declare clubTag = "";
+            if (Score.User.ClubTag != "") {
+              clubTag = color ^ "[" ^ Score.User.ClubTag ^ "$z" ^ color ^ "] ";
+            }
+            declare Text name = clubTag ^ color ^ nick ^ " $z" ^ color ^ icon;
+            Rank.Value = color^(i+1);
+            if (player == Null) {
+                Flag.Style = "UICommon64_2";
+                Flag.Substyle = "UserDelete_light";
+                Flag.ImageUrl = "";
+                Flag.ModulateColor = TL::ToColor("777");
+            } else {
+                Flag.ImageUrl = Score.User.CountryFlagUrl;
+                Flag.Style = "";
+                Flag.Substyle = "";
+                Flag.ModulateColor = TL::ToColor("fff");
+            }
+            Nick.Value = name;
+            declare Integer time = 0;
+            if (Score.BestRaceTimes.count > 0) {
+                time = Score.BestRaceTimes[Score.BestRaceTimes.count-1];
+            }
+            if (time <= 0) {
+              Time.Value = color ^ "--:--.---";
+            } else {
+              Time.Value = color ^ TL::TimeToText(time,True,True);
+            }
+        }
+    }
+}
+
+Void ScrollToUser() {
+    declare Integer index = 0;
+    foreach(i => Score in Scores) {
+        if (LocalUser == Score.User) {
+            index = i;
+        }
+    }
+    declare CMlFrame PlayerCards = (Page.GetFirstChild("playercards") as CMlFrame);
+    declare Real max = 5.5 * (index-20);
+    if (max < 0) max = 0.;
+    PlayerCards.ScrollOffset = <0. , max>;
+}
+
+***OnInit***
+***
+G_OldPageStatus = False;
+G_LastStamp = Now;
+G_LastUpdate = 0;
+declare CMlFrame Frame <=> (Page.GetFirstChild("details") as CMlFrame);
+G_Details.Flag = (Frame.GetFirstChild("flag") as CMlQuad);
+G_Details.Path = (Frame.GetFirstChild("path") as CMlLabel);
+G_Details.Name = (Frame.GetFirstChild("name") as CMlLabel);
+G_Details.UserId = (Frame.GetFirstChild("userid") as CMlEntry);
+G_Details.Login = (Frame.GetFirstChild("login") as CMlEntry);
+ClientUI.OverlayChatLineCount = 6;
+ClientUI.OverlayChatOffset = <0.0, 0.0>;
+Render();
+RenderDetails();
+***
+
+***OnMouseOver***
+***
+if (Event.Control.HasClass("hover")) {
+(Event.Control as CMlQuad).ModulateColor = TL::ToColor("3af");
+}
+***
+
+***OnMouseOut***
+***
+if (Event.Control.HasClass("hover")) {
+  declare Integer Rank = TL::ToInteger(Event.Control.Parent.DataAttributeGet("index"))+1;
+  (Event.Control as CMlQuad).ModulateColor = TL::ToColor("003");
+}
+***
+
+
+***OnMouseClick***
+***
+if (Event.Control == Null) continue;
+
+if (Event.Control.HasClass("hover")) {
+    G_DetailsIndex = TL::ToInteger(Event.Control.Parent.DataAttributeGet("index"));
+    if (IsSpectator) {
+        if (Scores.existskey(G_DetailsIndex)) {
+            SetSpectateTarget(Scores[G_DetailsIndex].User.Login);
+        }
+    }
+    RenderDetails();
+}
+
+if (Event.ControlId == "scroll-top") {
+    declare CMlFrame PlayerCards = (Page.GetFirstChild("scroll") as CMlFrame);
+    PlayerCards.ScrollOffset = <0. , 0.>;
+}
+
+if (Event.ControlId == "scroll-bottom") {
+    declare CMlFrame PlayerCards = (Page.GetFirstChild("scroll") as CMlFrame);
+    declare Real max = 5.5 * (Scores.count-20);
+    if (max < 0) max = 0.;
+    PlayerCards.ScrollOffset = <0. , max>;
+}
+
+if (Event.ControlId == "p_spectate") {
+    if (!IsSpectator) RequestSpectatorClient(True);
+
+    if (Scores.existskey(G_DetailsIndex)) {
+        SetSpectateTarget(Scores[G_DetailsIndex].User.Login);
+    }
+}
+
+if (Event.ControlId == "p_profile") {
+    if (Scores.existskey(G_DetailsIndex)) {
+        declare Text TMGame_ScoresTable_OpenProfileUserId for ClientUI = "";
+        TMGame_ScoresTable_OpenProfileUserId = G_Details.UserId.Value;
+    }
+}
+***
+
+***Loop***
+***
+
+if (G_LastUpdate != py_ScoreUpdate) {
+  G_LastUpdate = py_ScoreUpdate;
+  G_PlayerNames.fromjson(py_PlayerNames);
+  Render();
+}
+
+if (Now - G_LastStamp > 1000) {
+    G_LastStamp = Now;
+    Render();
+}
+***
+
+Void do_nothing() { }
+
+main() {
+    declare Text py_PlayerNames for This;
+    declare Integer py_ScoreUpdate for This = 0;
+
+    +++OnInit+++
+
+    while(True) {
+        yield;
+
+        if (PageIsVisible != G_OldPageStatus) {
+            G_OldPageStatus = PageIsVisible;
+            ScrollToUser();
+        }
+
+        if (!PageIsVisible) {
+            continue;
+        }
+
+        foreach (Event in PendingEvents) {
+            switch (Event.Type) {
+                case CMlScriptEvent::Type::EntrySubmit: {
+                    +++EntrySubmit+++
+                }
+                case CMlScriptEvent::Type::KeyPress: {
+                    +++OnKeyPress+++
+                }
+                case CMlScriptEvent::Type::MouseClick: {
+                    +++OnMouseClick+++
+                }
+                case CMlScriptEvent::Type::MouseOut: {
+                    +++OnMouseOut+++
+                }
+                case CMlScriptEvent::Type::MouseOver: {
+                    +++OnMouseOver+++
+                }
+            }
+        }
+
+        +++Loop+++
+    }
+}

--- a/it/thexivn/random_maps_together/templates/updater.xml
+++ b/it/thexivn/random_maps_together/templates/updater.xml
@@ -1,0 +1,10 @@
+<script><![CDATA[
+main() {
+  declare Integer poll_updater for This;
+  declare Text poll_data for This;
+
+	poll_updater = Now;
+	poll_data = """{{polljson|safe}}""";
+
+}
+]]></script>

--- a/it/thexivn/random_maps_together/templates/widget.xml
+++ b/it/thexivn/random_maps_together/templates/widget.xml
@@ -1,46 +1,39 @@
-{% extends 'core.views/generics/widget.xml' %}
+{% extends 'core.views/uikit/v1/widget.xml' %}
 
 {% block content %}
-    <frame pos="0 0" size="{{size_x}} {{size_y}}">
-        <quad pos="0 0" size="{{size_x}} {{size_y}}" z-index="0" bgcolor="10101070"/>
+   <frame pos="0 0">
+		<frame pos="-30 0" z-index="2">
+			<label pos="0 1" z-index="4" size="67 9" text="RANDOM MAPS" textsize="5" textfont="GameFontSemiBold" halign="center" valign="top"/>
+			<label pos="0 -5" z-index="2" size="73 7" text="T O G E T H E R" textsize="5" textfont="GameFontBlack" halign="center" valign="top" textcolor="000"/>
+			<quad pos="0 -5" z-index="1" size="50 6.5" bgcolor="FFF" halign="center" valign="top"/>
+		</frame>
         {% if game_started %}
-            <quad pos="0 0" size="10 10" z-index="1" image="https://imgur.com/s9qP3Pr.png" autoscale="1" keepratio="Fit"/>
-            <label pos="20 -2.2" z-index="1" text="{{AT}}" textsize="3.5" textfont="RajdhaniMono" halign="center" />
-            <quad pos="30 0" size="10 10" z-index="1" image="https://i.imgur.com/0z7NmIr.png" autoscale="1" keepratio="Fit"/>
-            <label pos="50 -2.2" z-index="1" text="{{GOLD}}" textsize="3.5" textfont="RajdhaniMono" halign="center" />
+            <quad pos="0 0" size="10 10" z-index="1" style="MedalsBig" substyle="MedalNadeoPerspective" autoscale="1" keepratio="Fit"/>
+            <label pos="20 -2.2" z-index="1" text="{{AT}}" textsize="3.5" textfont="GameFontBlack" halign="center" />
+            <quad pos="30 0" size="10 10" z-index="1" style="MedalsBig" substyle="MedalGoldPerspective" autoscale="1" keepratio="Fit"/>
+            <label pos="50 -2.2" z-index="1" text="{{GOLD}}" textsize="3.5" textfont="GameFontBlack" halign="center" />
         {% else %}
-            <label pos="30 -2" z-index="1" text="Welcome to RMT HUB" textsize="3.5" textfont="RajdhaniMono" halign="center" />
+            <label pos="30 -2" z-index="1" text="Welcome to RMT Lobby" textsize="3.5" textfont="GameFontSemiBold" halign="center" />
         {% endif %}
     </frame>
+
     {% if ui_tools_enabled %}
-        <frame pos="0 -{{size_y}}" size="{{size_x}} 5">
-            <quad pos="0 0" size="{{size_x}} 5" z-index="0" bgcolor="44664770"/>
+        <frame pos="0 -{{size_y}}">
             {% if game_started %}
                 {% if map_loading %}
                     <label pos="0 -2.5" size="{{size_x}} 5" z-index="1" text="LOADING NEXT MAP..."
-                           textsize="3" textfont="RajdhaniMono" halign="left" valign="center" />
+                           textsize="3" textfont="GameFontSemiBold" halign="left" valign="center" />
                 {% else %}
-                    <label pos="0 -2.5" size="25 5" z-index="1" text="Stop" textsize="2.5" textfont="RajdhaniMono"
-                           halign="left" valign="center" style="CardButtonSmallS"
-                           id="rmt_start_btn" scriptevents="1" action="{{ id }}__ui_stop_rmt" />
                     {% if gold_skip_visible %}
-                        <label pos="30 -2.5" size="25 5" z-index="1" text="Take GOLD" textsize="2.5" textfont="RajdhaniMono"
-                               halign="left" valign="center" style="CardButtonSmallS"
-                               id="rmt_gold_btn" scriptevents="1" action="{{ id }}__ui_gold_skips" />
-                    {% else %}
-                        {% if free_skip_visible %}
-                            <label pos="30 -2.5" size="28 5" z-index="1" text="Skip" textsize="2.5" textfont="RajdhaniMono"
-                                   halign="left" valign="center" style="CardButtonSmallS"
-                                   id="rmt_skip_btn" scriptevents="1" action="{{ id }}__ui_free_skip" />
-                        {% endif %}
+                        <label pos="0 -2.5" size="50 5" z-index="1" text="Vote Available: /gold_skip" textsize="1.5" textfont="GameFontSemiBold"
+                               halign="left" valign="center" action="{{id}}__votegold" />
                     {% endif %}
                 {% endif %}
-            {% else %}
-                <label pos="0 -2.5" size="30 5" z-index="1" text="Start RMT" textsize="2.5" textfont="RajdhaniMono"
-                       halign="left" valign="center" style="CardButtonSmall"
-                       id="rmt_stop_btn" scriptevents="1" action="{{ id }}__ui_start_rmt" />
             {% endif %}
-
         </frame>
     {% endif %}
+{% endblock %}
+
+{% block maniascript %}
+  <script><!--{% include 'core.views/uikit/v1/scripts/toggle_ui.Script.txt' %} --></script>
 {% endblock %}

--- a/it/thexivn/random_maps_together/views.py
+++ b/it/thexivn/random_maps_together/views.py
@@ -1,27 +1,29 @@
 import logging
+import json
+import time as py_time
 from typing import Optional
 
 from pyplanet.views import TemplateView
-from pyplanet.views.generics.widget import TimesWidgetView
+from pyplanet.views.generics.widget import WidgetView
 
-from it.thexivn.random_maps_together.Data.GameScore import GameScore
-from it.thexivn.random_maps_together.Data.GameState import GameState
+from apps.it.thexivn.random_maps_together.Data.GameScore import GameScore
+from apps.it.thexivn.random_maps_together.Data.GameState import GameState
 
 logger = logging.getLogger(__name__)
 
 
-class RandomMapsTogetherView(TimesWidgetView):
+class RandomMapsTogetherView(WidgetView):
     widget_x = -100
     widget_y = 89
     z_index = 5
     size_x = 60
     size_y = 10
-    title = "Random Maps Together"
+    title = ""
 
     template_name = "random_maps_together/widget.xml"
 
     def __init__(self, app):
-        super().__init__(self)
+        super().__init__()
         logger.info("Loading VIEW")
         self.app = app
         self.manager = app.context.ui
@@ -43,6 +45,7 @@ class RandomMapsTogetherView(TimesWidgetView):
     async def get_context_data(self):
         logger.info("Context Data")
         data = await super().get_context_data()
+        data['ui_tools_enabled'] = self.ui_controls_visible
         if self._score:
             data["AT"] = self._score.total_at
             data["GOLD"] = self._score.total_gold
@@ -50,7 +53,6 @@ class RandomMapsTogetherView(TimesWidgetView):
             data["AT"] = 0
             data["GOLD"] = 0
 
-        data["ui_tools_enabled"] = self.ui_controls_visible
         if self._game_state:
             data["game_started"] = self._game_state.game_is_in_progress
             data["gold_skip_visible"] = self._game_state.gold_skip_available
@@ -66,8 +68,9 @@ class RMTScoreBoard(TemplateView):
     template_name = "random_maps_together/score_board.xml"
 
     def __init__(self, app, score: GameScore):
-        super().__init__(self)
+        super().__init__()
         logger.info("Loading VIEW")
+        self.layer = "ScoresTable"
         self.app = app
         self.manager = app.context.ui
         self.id = "it_thexivn_RandomMapsTogether_score_board"
@@ -88,8 +91,83 @@ class RMTScoreBoard(TemplateView):
         data = await super().get_context_data()
         data["AT"] = self._score.total_at
         data["GOLD"] = self._score.total_gold
-
-        data["players"] = self._score.get_top_10()
+        data["players"] = self._score.get_top(10)
         data["time_left"] = self._time_left
 
         return data
+
+
+class MapInfoWidget(WidgetView):
+    widget_x = 160
+    widget_y = 88
+    z_index = 30
+
+    template_name = "random_maps_together/mapinfo.xml"
+
+    def __init__(self, app):
+        super().__init__(self)
+        self.app = app
+        self.manager = app.context.ui
+        self.id = 'pyplanet__widgets_mapinfo'
+
+
+class PollView(TemplateView):
+    z_index = 30
+
+    template_name = "random_maps_together/poll.xml"
+
+    def __init__(self, app, manager):
+        super().__init__()
+        self.app = app
+        self.manager = manager
+        self.id = 'rmt_poll'
+
+
+class PollUpdaterView(TemplateView):
+    template_name = 'random_maps_together/updater.xml'
+
+    def __init__(self, app, manager, *args, **kwargs):
+        super().__init__()
+        self.app = app
+        self.manager = manager
+        self.id = 'rmt__updater'
+
+    async def get_context_data(self):
+        jsondata = {
+            "Votes": self.app.poll_votes,
+            "Limit": int(self.app.poll_time - py_time.time()),
+        }
+        data = {
+            "polljson": json.dumps(jsondata)
+        }
+        return data
+
+
+class PlayerUpdaterView(TemplateView):
+    template_name = "random_maps_together/player_updater.xml"
+
+    def __init__(self, app):
+        super().__init__()
+        self.app = app
+        self.manager = app.context.ui
+        self.id = 'pyplanet__scoretable_updater'
+        self.title = "Scoretable Updater"
+
+    async def get_context_data(self):
+        player_data = []
+        for player in self.app.instance.player_manager.online:
+            player_data.append(
+                {
+                    "Login": player.login,
+                    "Nick": player.nickname
+                })
+
+        return {
+            "playerjson": json.dumps(player_data),
+            'num_players': self.app.instance.player_manager.count_players,
+            'max_players': self.app.instance.player_manager.max_players,
+            'num_spectators': self.app.instance.player_manager.count_spectators,
+            'max_spectators': self.app.instance.player_manager.max_spectators,
+        }
+
+

--- a/it/thexivn/random_maps_together/views.py
+++ b/it/thexivn/random_maps_together/views.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from pyplanet.views import TemplateView
 from pyplanet.views.generics.widget import TimesWidgetView
@@ -67,6 +68,17 @@ class RMTScoreBoard(TemplateView):
         self.manager = app.context.ui
         self.id = "it_thexivn_RandomMapsTogether_score_board"
         self._score: GameScore = score
+        self._time_left: Optional[str] = None
+
+    def set_time_left(self, time_left_seconds: int):
+        if time_left_seconds <= 0:
+            self._time_left = None
+        elif time_left_seconds < 60:
+            self._time_left = f'00:{time_left_seconds:02d}'
+        else:
+            minutes_left = int(time_left_seconds / 60)
+            seconds_left = time_left_seconds - minutes_left * 60
+            self._time_left = f'{minutes_left:02d}:{seconds_left:02d}'
 
     async def get_context_data(self):
         data = await super().get_context_data()
@@ -74,5 +86,6 @@ class RMTScoreBoard(TemplateView):
         data["GOLD"] = self._score.total_gold
 
         data["players"] = self._score.get_top_10()
+        data["time_left"] = self._time_left
 
         return data

--- a/it/thexivn/random_maps_together/views.py
+++ b/it/thexivn/random_maps_together/views.py
@@ -29,12 +29,16 @@ class RandomMapsTogetherView(TimesWidgetView):
         self._score: GameScore = None
         self.ui_controls_visible = True
         self._game_state: GameState = None
+        self._skippable_map = False
 
     def set_score(self, score: GameScore):
         self._score = score
 
     def set_game_state(self, state: GameState):
         self._game_state = state
+
+    def set_skippable_map(self, skip: bool):
+        self._skippable_map = skip
 
     async def get_context_data(self):
         logger.info("Context Data")
@@ -50,7 +54,7 @@ class RandomMapsTogetherView(TimesWidgetView):
         if self._game_state:
             data["game_started"] = self._game_state.game_is_in_progress
             data["gold_skip_visible"] = self._game_state.gold_skip_available
-            data["free_skip_visible"] = self._game_state.free_skip_available
+            data["free_skip_visible"] = self._game_state.free_skip_available or self._skippable_map
             data["map_loading"] = self._game_state.map_is_loading
         else:
             data["game_started"] = False

--- a/it/thexivn/random_maps_together/views.py
+++ b/it/thexivn/random_maps_together/views.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 
 class RandomMapsTogetherView(TimesWidgetView):
-    widget_x = -140
-    widget_y = 85
+    widget_x = -100
+    widget_y = 89
     z_index = 5
     size_x = 60
     size_y = 10

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ PKG = 'random_maps_together'
 ######
 setup(
     name=PKG,
-    version='0.0.3',
+    version='0.0.4',
     description='Simple pyplanet application to add RMC mode online',
     long_description='',
     keywords='maniaplanet, pyplanet, RMC, trackmania',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ PKG = 'random_maps_together'
 ######
 setup(
     name=PKG,
-    version='0.0.2',
+    version='0.0.3',
     description='Simple pyplanet application to add RMC mode online',
     long_description='',
     keywords='maniaplanet, pyplanet, RMC, trackmania',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(
     extras_require={},
     include_package_data=True,
     long_description_content_type='text/markdown',
-
+    package_data={
+        'templates': ['*.xml', '*.Script.Txt']
+    },
     author='thexivn',
     author_email='thexivn@proton.me',
     url='https://github.com/thexivn/RandomMapTogether',


### PR DESCRIPTION
Some extra adaptation for RMT, seen at `unlimited rmt` server.
I prefixed the namespaces with app.it, so i don't need to run external installers and the plugin works directly from the app folder.

## Additions:
- fixed #2 on windows, using WriteFile method of dedicated server instead of pyplanet driver
- disable "records world"
- set limit max 1 min maps
- add gold time to ui
- add gold_skip vote (needs my votes plugin)
- add free_skip vote (needs my votes plugin)
- add confirmation dialog for //free_skip admin command
- fallback to use XertoVs cached tmx, when actual tmx is down
- show rules when player joins
- redone UI totally
- a new scoreboard (though you need my pyplanet fork to use the scorestable layer)
- possibility to run all random maps or with specific tags (//settings --> tags)
- poll ui with tmx tags to vote
 
## Admin commands for RMT:
  //poll
  //start_rmt
  //stop_rmt
  //free_skip
  //take_gold

you can reach me discord as well with same login as here
